### PR TITLE
Fix selenium_scraping_tool Chrome options

### DIFF
--- a/crewai_tools/tools/selenium_scraping_tool/selenium_scraping_tool.py
+++ b/crewai_tools/tools/selenium_scraping_tool/selenium_scraping_tool.py
@@ -5,7 +5,7 @@ from pydantic.v1 import BaseModel, Field
 from bs4 import BeautifulSoup
 from selenium import webdriver
 from selenium.webdriver.common.by import By
-from selenium.webdriver.firefox.options import Options
+from selenium.webdriver.chrome.options import Options
 
 from ..base_tool import BaseTool
 


### PR DESCRIPTION
This PR fixes the import of Firefox options, replacing it with Chrome options.

## Context
The default WebDriver defined is Chrome:
https://github.com/celobusana/crewAI-tools/blob/9def312914ea25818140d381e1e88a0398d461cb/crewai_tools/tools/selenium_scraping_tool/selenium_scraping_tool.py#L26

However, the options are set for Firefox, resulting in a failure to use the Selenium scraping tool.

## Testing script
```
from crewai_tools import SeleniumScrapingTool

tool = SeleniumScrapingTool()
tool = SeleniumScrapingTool(website_url='https://www.selenium.dev/selenium/web/web-form.html')

text = tool.run()
print(text)
```

### Before
```
python tests/web_scraper.py 
Using Tool: Read a website content
...
File "/home/marcelo/crewai/venv/lib/python3.12/site-packages/selenium/webdriver/remote/errorhandler.py", line 229, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.InvalidArgumentException: Message: binary is not a Firefox executable

```
### After

```
python tests/web_scraper.py 
Using Tool: Read a website content
Web form
Text input
Password
Textarea
Disabled input
Readonly input
Return to index
Dropdown (select)
                Open this select menu
                One
                Two
                Three
               Dropdown (datalist)
File input
Checked checkbox
Default checkbox
Checked radio
Default radio
Submit
Color picker
Date picker
Example range
```